### PR TITLE
Remove stdbuf dependancy, macOS instructions added

### DIFF
--- a/One Constant Zone/AdvAir.sh
+++ b/One Constant Zone/AdvAir.sh
@@ -211,7 +211,7 @@ if [ "$io" = "Get" ]; then
          # Updates global variable jqResult
          queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.zones.'"$zone"'.measuredTemp'
 
-         stdbuf -o0 -e0 echo "$jqResult"
+         echo "$jqResult"
 
          exit 0
       ;;
@@ -221,14 +221,14 @@ if [ "$io" = "Get" ]; then
          # Updates global variable jqResult
          queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.info.setTemp'
 
-         stdbuf -o0 -e0 echo "$jqResult"
+         echo "$jqResult"
 
          exit 0
       ;;
 
       # Sets display units to Celsius.
       TemperatureDisplayUnits )
-         stdbuf -o0 -e0 echo 0
+         echo 0
 
          exit 0
       ;;
@@ -240,7 +240,7 @@ if [ "$io" = "Get" ]; then
          queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.info.state'
 
          if [  "$jqResult" = '"off"' ]; then
-            stdbuf -o0 -e0 echo 0
+            echo 0
 
             exit 0
          else
@@ -252,35 +252,35 @@ if [ "$io" = "Get" ]; then
             case "$mode" in
                '"heat"' )
                   # Thermostat in Heat Mode.
-                  stdbuf -o0 -e0 echo 1
+                  echo 1
 
                   exit 0
                ;;
 
                '"cool"' )
                   # Thermostat in Cool Mode.
-                 stdbuf -o0 -e0 echo 2
+                 echo 2
 
                  exit 0
                ;;
 
                '"vent"' )
                   # Fan mode, set Thermostat to Off and Fan to On.
-                  stdbuf -o0 -e0 echo 0
+                  echo 0
 
                   exit 0
                ;;
 
                '"dry"' )
                   # No support for a dry mode by Apple, set to Off.
-                  stdbuf -o0 -e0 echo 0
+                  echo 0
 
                   exit 0
                ;;
 
                * )
                   # If anything unexpected is retruned than the above, return value Off.
-                  stdbuf -o0 -e0 echo 0
+                  echo 0
 
                   exit 0
                ;;
@@ -295,7 +295,7 @@ if [ "$io" = "Get" ]; then
             queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.info.state'
 
             if [  "$jqResult" = '"off"' ]; then
-               stdbuf -o0 -e0 echo 0
+               echo 0
 
                exit 0
             else
@@ -307,35 +307,35 @@ if [ "$io" = "Get" ]; then
                case "$mode" in
                   '"heat"' )
                      # Fan does not support Heat Mode.
-                     stdbuf -o0 -e0 echo 0
+                     echo 0
 
                      exit 0
                   ;;
 
                   '"cool"' )
                      # Fan does not support Cool Mode.
-                     stdbuf -o0 -e0 echo 0
+                     echo 0
 
                      exit 0
                   ;;
 
                   '"vent"' )
                      # Set Fan to On.
-                     stdbuf -o0 -e0 echo 1
+                     echo 1
 
                      exit 0
                   ;;
 
                   '"dry"' )
                      # Fan does not support Dry Mode.
-                     stdbuf -o0 -e0 echo 0
+                     echo 0
 
                      exit 0
                   ;;
 
                   * )
                      # If anything unexpected is retruned than the above, set to Off.
-                     stdbuf -o0 -e0 echo 0
+                     echo 0
 
                      exit 0
                   ;;
@@ -350,11 +350,11 @@ if [ "$io" = "Get" ]; then
             queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.zones.'"$zone"'.state'
 
             if [ "$jqResult" = '"open"' ]; then
-               stdbuf -o0 -e0 echo 1
+               echo 1
 
                exit 0
             else
-               stdbuf -o0 -e0 echo 0
+               echo 0
 
                exit 0
             fi
@@ -367,11 +367,11 @@ if [ "$io" = "Get" ]; then
          queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.zones.'"$zone"'.error'
 
          if [ "$jqResult" = '0' ]; then
-            stdbuf -o0 -e0 echo 0
+            echo 0
 
             exit 0
          else
-            stdbuf -o0 -e0 echo 1
+            echo 1
 
             exit 0
          fi

--- a/One Constant Zone/AdvAir.sh
+++ b/One Constant Zone/AdvAir.sh
@@ -2,8 +2,8 @@
 
 # A massive thank you to John Talbot of homebridge-cmd4 for all his work on improving this shell script and the improvements to homebridge-cmd4 to cater further for the Advantage Air controller.
 
-# IP Address / Port:
-IP="192.168.0.173:2025"
+# IP Address:
+IP="192.168.0.173"
 
 ##################################################################################################################################################################################################
 ##################################################################################################################################################################################################
@@ -209,7 +209,7 @@ if [ "$io" = "Get" ]; then
       # Gets the current temperature.
       CurrentTemperature )
          # Updates global variable jqResult
-         queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.zones.'"$zone"'.measuredTemp'
+         queryAndParseAirCon "http://$IP:2025/getSystemData" '.aircons.ac1.zones.'"$zone"'.measuredTemp'
 
          echo "$jqResult"
 
@@ -219,7 +219,7 @@ if [ "$io" = "Get" ]; then
       # Gets the target temperature.
       TargetTemperature )
          # Updates global variable jqResult
-         queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.info.setTemp'
+         queryAndParseAirCon "http://$IP:2025/getSystemData" '.aircons.ac1.info.setTemp'
 
          echo "$jqResult"
 
@@ -237,7 +237,7 @@ if [ "$io" = "Get" ]; then
       TargetHeatingCoolingState | CurrentHeatingCoolingState )
          # Set to Off if the zone is closed or the Control Unit is Off.
          # Updates global variable jqResult
-         queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.info.state'
+         queryAndParseAirCon "http://$IP:2025/getSystemData" '.aircons.ac1.info.state'
 
          if [  "$jqResult" = '"off"' ]; then
             echo 0
@@ -292,7 +292,7 @@ if [ "$io" = "Get" ]; then
          if [ $zoneSpecified = false ]; then
             # Return value of Off if the zone is closed or the Control Unit is Off.
             # Updates global variable jqResult
-            queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.info.state'
+            queryAndParseAirCon "http://$IP:2025/getSystemData" '.aircons.ac1.info.state'
 
             if [  "$jqResult" = '"off"' ]; then
                echo 0
@@ -347,7 +347,7 @@ if [ "$io" = "Get" ]; then
             # Change to On just so we can leave it here for now
             # and it will not get called
             # Updates global variable jqResult
-            queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.zones.'"$zone"'.state'
+            queryAndParseAirCon "http://$IP:2025/getSystemData" '.aircons.ac1.zones.'"$zone"'.state'
 
             if [ "$jqResult" = '"open"' ]; then
                echo 1
@@ -364,7 +364,7 @@ if [ "$io" = "Get" ]; then
       #Temp Sensor Fault Status = no fault/fault = 0/1-2
       StatusLowBattery )
          # Updates global variable jqResult
-         queryAndParseAirCon "http://$IP/getSystemData" '.aircons.ac1.zones.'"$zone"'.error'
+         queryAndParseAirCon "http://$IP:2025/getSystemData" '.aircons.ac1.zones.'"$zone"'.error'
 
          if [ "$jqResult" = '0' ]; then
             echo 0
@@ -417,19 +417,19 @@ if [ "$io" = "Set" ]; then
          case "$value" in
             0 )
                # Shut Off Control Unit.
-               queryAirCon "http://$IP/setAircon?json={ac1:{info:{state:off}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{info:{state:off}}}" "1" "0"
 
                exit 0
             ;;
             1 )
                # Turn On Control Unit, Set Mode to Heat, Open Current Zone.
-               queryAirCon "http://$IP/setAircon?json={ac1:{info:{state:on,mode:heat}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{info:{state:on,mode:heat}}}" "1" "0"
 
                exit 0
             ;;
             2 )
                # Turn On Control Unit, Set Mode to Cool, Open Current Zone.
-               queryAirCon "http://$IP/setAircon?json={ac1:{info:{state:on,mode:cool}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{info:{state:on,mode:cool}}}" "1" "0"
 
                exit 0
             ;;
@@ -438,7 +438,7 @@ if [ "$io" = "Set" ]; then
 
       TargetTemperature )
          # Sets all zones to the current 'master' thermostat's value. All 10 allowable zones have been added just in case and do not need removing.
-         queryAirCon "http://$IP/setAircon?json={ac1:{info:{setTemp:$value},zones:{z01:{setTemp:$value},z02:{setTemp:$value},z03:{setTemp:$value},z04:{setTemp:$value},z05:{setTemp:$value},z06:{setTemp:$value},z07:{setTemp:$value},z08:{setTemp:$value},z09:{setTemp:$value},z10:{setTemp:$value}}}}" "1" "0"
+         queryAirCon "http://$IP:2025/setAircon?json={ac1:{info:{setTemp:$value},zones:{z01:{setTemp:$value},z02:{setTemp:$value},z03:{setTemp:$value},z04:{setTemp:$value},z05:{setTemp:$value},z06:{setTemp:$value},z07:{setTemp:$value},z08:{setTemp:$value},z09:{setTemp:$value},z10:{setTemp:$value}}}}" "1" "0"
 
          exit 0
       ;;
@@ -447,22 +447,22 @@ if [ "$io" = "Set" ]; then
          if [ $zoneSpecified = false ]; then  # ( ezone )
             if [ "$value" = "1" ]; then
                # Sets Control Unit to On, sets to Fan mode and Auto; opens the zone. Apple does not support 'low', 'medium' and 'high' fan modes.
-               queryAirCon "http://$IP/setAircon?json={ac1:{info:{state:on,mode:vent,fan:auto}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{info:{state:on,mode:vent,fan:auto}}}" "1" "0"
 
                exit 0
             else
                # Shut Off Control Unit.
-               queryAirCon "http://$IP/setAircon?json={ac1:{info:{state:off}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{info:{state:off}}}" "1" "0"
 
                exit 0
             fi
          else
             if [ "$value" = "1" ]; then
-               queryAirCon "http://$IP/setAircon?json={ac1:{zones:{$zone:{state:open}}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{zones:{$zone:{state:open}}}}" "1" "0"
 
                exit 0
             else
-               queryAirCon "http://$IP/setAircon?json={ac1:{zones:{$zone:{state:close}}}}" "1" "0"
+               queryAirCon "http://$IP:2025/setAircon?json={ac1:{zones:{$zone:{state:close}}}}" "1" "0"
 
                exit 0
             fi

--- a/README.md
+++ b/README.md
@@ -24,23 +24,12 @@ No affiliation with Advantage Air or any of their products.
 * Confrimed:
   * [e-zone](https://apps.apple.com/au/app/e-zone/id925994857)
   * [MyAir](https://apps.apple.com/au/app/myair/id481563583)
-  * [zone10e](https://apps.apple.com/au/app/zone10e/id1076850364)
-* Unconfirmed:
   * [MyAir3](https://apps.apple.com/au/app/myair3/id645762642)
   * [MyAir4](https://apps.apple.com/au/app/myair4/id925994861)
+  * [zone10e](https://apps.apple.com/au/app/zone10e/id1076850364)
+* Unconfirmed:
   * [MyPlace](https://apps.apple.com/au/app/myplace/id996398299)
   * [zone10](https://apps.apple.com/au/app/zone10/id510581478)
-
-## Installation:
-1. Install [Homebridge](https://github.com/homebridge/homebridge#installation).
-2. Install the [homebridge-cmd4](https://github.com/ztalbot2000/homebridge-cmd4) plug-in through the config-ui-x web UI or via terminal command: `sudo npm install -g --unsafe-perm homebridge-cmd4`. Note: you do not need to follow the extra installation steps on cmd4's page for this.
-3. For users with only One Constant Zone (single storey home), the script is the same for users with or without Temperature Sensors. For users with Two Constant Zones you will have to navigate through 'Old Scripts' directory to find your relevant scripts (there will be two scripts for these users); upgrading the Two Constant Zones scripts is on the To-Do List.
-4. Edit `AdvAir.sh` with the IP address of your Advantage Air controller. If you have two constant zones, then you will need to edit your IP Address and Constant Zones at the top of `ezone.sh` (you still need to use two scripts sorry!).
-5. Copy `AdvAir.sh` (or `ezone.sh` and `zones.sh`) to a subdirectory of your `.homebridge` directory; e.g. `.homebridge/Cmd4Scripts/AdvAir.sh`. Mine is located in `/home/pi/AdvAir.sh`. 
-6. <B>OR</B> if you are less savvy like me, you can create the script in your homedrive of your raspberry pi using `sudo nano AdvAir.sh` and pasting the contents inside, then saving. Its pathway in this case will be `/home/pi/AdvAir.sh`. For HOOBS users this would create your shell scripts at the lcation: `/home/hoobs/.hoobs/AdvAir.sh`.
-7. Install <B>jq</B>; `sudo apt-get install jq`. Make sure `curl` is installed (it should already be installed).
-8. Edit your homebridge `config.json` using the samples included in each directory for your appropriate setup; this should be completed from the config-ui-x web UI.
-9. Restart Homebridge.
 
 ## How It Looks:
 <p align="center">
@@ -51,21 +40,59 @@ No affiliation with Advantage Air or any of their products.
 
 </p>
 
+## Installation:
+### Raspbian/HOOBS:
+1. Install [Homebridge](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Raspbian).
+2. Install the [homebridge-cmd4](https://github.com/ztalbot2000/homebridge-cmd4) plug-in through the [Homebridge web UI](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-Raspbian#complete-login-to-the-homebridge-ui) or via terminal command:
+`sudo npm install -g --unsafe-perm homebridge-cmd4`. <I><B>NOTE:</I></B> you do not need to follow the extra installation steps on cmd4's page for this.
+3. For users with only One Constant Zone (single storey home), the script is the same for users with or without Temperature Sensors. For users with Two Constant Zones you will have to navigate through 'Old Scripts' directory to find your relevant scripts (there will be two scripts for these users); upgrading the Two Constant Zones scripts is on the To-Do List.
+4. Edit `AdvAir.sh` with the IP address of your Advantage Air controller. If you have two constant zones, then you will need to edit your IP Address and Constant Zones at the top of `ezone.sh` and `zones.sh` (you still need to use two scripts sorry!).
+5. Copy `AdvAir.sh` (or `ezone.sh` and `zones.sh` for Two Constant Zone Users) to a subdirectory of your `.homebridge` directory; e.g. `.homebridge/Cmd4Scripts/AdvAir.sh`. I suggest doing this from the web UI terminal (`...` top, right hand corner). Mine file is located in `/home/pi/AdvAir.sh`. 
+6. <B>OR</B> if you are less savvy like me, you can create the script in your homedrive (type `cd` in your terminal and hit enter to get there) of your Raspberry Pi using `sudo nano AdvAir.sh` and pasting the contents inside, then saving. Its pathway in this case to be used in our config will be `/home/pi/AdvAir.sh`. For HOOBS users this would create your shell scripts at the lcation: `/home/hoobs/.hoobs/AdvAir.sh`.
+7. Install <B>jq</B>; `sudo apt-get install jq`. Make sure `curl` is installed (it should already be installed).
+8. Edit your homebridge `config.json` using the samples included in each directory for your appropriate setup; this should be completed from the Homebridge web UI. <I><B>NOTE:</I></B> Two devices cannot have the exact same name in your config. A switch and temperature sensor cannot both be named 'Kitchen' for example. 
+9. Restart Homebridge.
+
+### macOS
+1. Install [Homebridge](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-macOS).
+2. Install the [homebridge-cmd4](https://github.com/ztalbot2000/homebridge-cmd4) plug-in through the [Homebridge web UI](https://github.com/homebridge/homebridge/wiki/Install-Homebridge-on-macOS#complete-login-to-the-homebridge-ui) or via terminal command:
+`sudo npm install -g --unsafe-perm homebridge-cmd4`. <I><B>NOTE:</I></B> you do not need to follow the extra installation steps on cmd4's page for this.
+3. For users with only One Constant Zone (single storey home), the script is the same for users with or without Temperature Sensors. For users with Two Constant Zones you will have to navigate through 'Old Scripts' directory to find your relevant scripts (there will be two scripts for these users); upgrading the Two Constant Zones scripts is on the To-Do List.
+4. Edit `AdvAir.sh` with the IP address of your Advantage Air controller. If you have two constant zones, then you will need to edit your IP Address and Constant Zones at the top of `ezone.sh` and `zones.sh` (you still need to use two scripts sorry!).
+5. Copy `AdvAir.sh` (or `ezone.sh` and `zones.sh` for Two Constant Zone Users) to a subdirectory of your `.homebridge` directory; e.g. `.homebridge/Cmd4Scripts/AdvAir.sh`. I suggest doing this from the macOS terminal like how you installed Homebridge. When I tested this on my wife's MacBook; mine was located in `/Users/hername/AdvAir.sh`. 
+6. <B>OR</B> if you are less savvy like me, you can create the script in your homedrive (type `cd` in your terminal and hit enter to get there) of your MacBook using `sudo nano AdvAir.sh` and pasting the contents inside, then saving. Its pathway in this case to be used in our config will be `/Users/hername/AdvAir.sh`.
+7. Install <B>jq</B>; `brew install jq` (you may need to install [brew](https://brew.sh/) first or you may use `port`). 
+8. Install <B>curl</B>; `brew install curl`
+9. Edit your homebridge `config.json` using the samples included in each directory for your appropriate setup; this should be completed from the Homebridge web UI. <I><B>NOTE:</I></B> Two devices cannot have the exact same name in your config. A switch and temperature sensor cannot both be named 'Kitchen' for example. 
+10. Restart Homebridge.
+
+### Windows 10
+I have not successfully set this up on Windows 10 Homebridge server yet. If you have and want to contribute; please reach out and let me know how you did it. Otherwise I strongly suggest you buy a dedicated Raspberry Pi.
+
 ## About:
 Due to the current limitations in Homekit, multi-zoned ducted air conditioners are not represented as a single accessory. Our work around here is two create multiple accessories:
-1. A Thermostat with modes <B>OFF/HEAT/COOL</B> using the Advantage Air 'constant' zone (usually zone 1 in a one 'constant zone' setup) as the measured temperature for feedback. <B><I>NOTE:</B></I> <B>AUTO</B> mode in Homekit is not used in Advantage Air controllers, so it will set the controller to <B>OFF</B>. Setting <B>DRY</B> mode from the controller will then represent in Homekit as <B>OFF</B>. 
-2. A simple Fan with modes <B>OFF/ON</B> (for the time being) for the controller's <B>FAN</B> mode. <B><I>NOTE:</B></I> Turning the Fan accessory on in Homekit will turn off the Thermostat accessory, and turning the Thermostat accessory on in homekit will turn off the Fan Accessory. When the Fan is turned on in Homekit, it will also execute the <B>AUTO</B> mode in the respective Advantage Air app; just to keep it simple for now.
-3. Temperature Sensors with feedback from each zone. These also include the <B>FAULT</B> status in the accessory, this is determined by the error codes produced by the controller. <B><I>NOTE:</B></I> According to the Advantage Air developers there is only one fault code; which is used for low battery, dead battery and loss of connection to sensor. I could not get any further information about this and have only seen one fault myself.
-4. A sample version of the `config.json` has been added for users who do not have the Temperature Sensors.
-5. Versions of the shell scripts have been added for users who have two 'constant zones' (two storey house typically). According to Advantage Air only one constant zone has to be on at any time; some logic has been added to the shell scripts for two 'constant zones' to either shut off the zone or turn off the entire controller based on if the other 'constant zone' is open or not; to make sure your air conditioner and ducting are protected.
-6. Switches with feedback to open and close each zone. <B><I>NOTE: I do not recommend adding your 'constant zones' (usually zone 1, but there can be a second; represented as a 'C' in the app) as a Switch in Homekit as this zone is not meant to be turned off. I am not responsible for any damage to your ducting if you do manage to shut this zone (not sure it is possible, but just in case) and run the air conditioner.</B></I>
+* A Thermostat with modes <B>OFF/HEAT/COOL</B> using the Advantage Air 'constant' zone (usually zone 1 in a one 'constant zone' setup) as the measured temperature for feedback. <B><I>NOTE:</B></I> <B>AUTO</B> mode in Homekit is not used in Advantage Air controllers, so it will set the controller to <B>OFF</B>. Setting <B>DRY</B> mode from the controller will then represent in Homekit as <B>OFF</B>. 
+* A simple Fan with modes <B>OFF/ON</B> (for the time being) for the controller's <B>FAN</B> mode. <B><I>NOTE:</B></I> Turning the Fan accessory on in Homekit will turn off the Thermostat accessory, and turning the Thermostat accessory on in homekit will turn off the Fan Accessory. When the Fan is turned on in Homekit, it will also execute the <B>AUTO</B> mode in the respective Advantage Air app; just to keep it simple for now.
+* Temperature Sensors with feedback from each zone. These also include the <B>FAULT</B> status in the accessory, this is determined by the error codes produced by the controller. <B><I>NOTE:</B></I> According to the Advantage Air developers there is only one fault code; which is used for low battery, dead battery and loss of connection to sensor. I could not get any further information about this and have only seen one fault myself.
+* A sample version of the `config.json` has been added for users who do not have the Temperature Sensors.
+* Versions of the shell scripts have been added for users who have two 'constant zones' (two storey house typically). According to Advantage Air only one constant zone has to be on at any time; some logic has been added to the shell scripts for two 'constant zones' to either shut off the zone or turn off the entire controller based on if the other 'constant zone' is open or not; to make sure your air conditioner and ducting are protected.
+* Switches with feedback to open and close each zone. <B><I>NOTE: I do not recommend adding your 'constant zones' (usually zone 1, but there can be a second; represented as a 'C' in the app) as a Switch in Homekit as this zone is not meant to be turned off. I am not responsible for any damage to your ducting if you do manage to shut this zone (not sure it is possible, but just in case) and run the air conditioner.</B></I>
 
 ## How to Keep Up-To-Date:
 As this is not a typical homebridge plug-in, you will not get prompted to update when I add improvements. The best way to keep up-to-date is to click the `Watch` button in the top right corner and select `All Activity` or `Custom` and then `Releases`. This will ensure you get an email everytime I push a new release with new features or improvements! Feel free to give me a `Star` as well if you are happy with the work.
 
+
+## How You Can Help:
+* Open Issues/Tickets.
+* Report Bugs/Errors.
+* Suggest Improvements and Features you would like to see!
+* Let me know if you have a Control Unit or App that works that is not confirmed in my [Supported List](https://github.com/mitch7391/cmd4-AdvantageAir#supported-control-units)!
+* Let me know if you can figure out how to get this running on Windows 10 Homebridge.
+* Feel free to let me know you are loving set up! 
+
 ## Further Notes:
-1. I have only tested this on my own E-zone Advantage Air controller, but the API is exactly the same for MyAir and the named devices at the begining of this README; that is actually where I was able to get the commands and learn how to structure them properly. The API can be found [here](http://advantageair.proboards.com/) once you have registered.
-2. I am not very savvy with all of this coding work and had a lot of help and direction as I 'learn as I go'; this was a learning curve for me but I plan to keep working on this and improving it.
+* I have only tested this on my own E-zone Advantage Air controller, but the API is exactly the same for MyAir and the named devices at the begining of this README; that is actually where I was able to get the commands and learn how to structure them properly. The API can be found [here](http://advantageair.proboards.com/) once you have registered.
+* I am not very savvy with all of this coding work and had a lot of help and direction as I 'learn as I go'; this was a learning curve for me but I plan to keep working on this and improving it.
 
 ## Potential Device Limitations:
 What we have discovered from over 8 months of trying to improve performance and reduce homebridge/cmd4 log warnings: 


### PR DESCRIPTION
Minor changes: 
* Removed `stdbuf` dependency from scripts (could affect macOS user installs).
* Install instructions split into Raspian and macOS installs.
* IP Address / Port Number at start of script has moved the port number into the script commands; so users do not need to think they need to change the port number or figure it out.